### PR TITLE
hotfix/syncHook

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@bentoo/state-man",
     "description": "A lightweight package for state management in React applications, designed as a simplified alternative to Zustand and the Context API.",
     "private": false,
-    "version": "1.0.0",
+    "version": "1.0.1",
     "type": "module",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/src/__tests__/store.test.tsx
+++ b/src/__tests__/store.test.tsx
@@ -38,7 +38,8 @@ describe("Store", () => {
             return () => {};
         });
         const snapshot = vi.fn(() => {});
-        renderHook(() => createExternalStore(subscribe, snapshot));
+        const serverSnapshot = vi.fn(() => {});
+        renderHook(() => createExternalStore(subscribe, snapshot, serverSnapshot));
         expect(subscribe).toHaveBeenCalled();
         expect(snapshot).toHaveBeenCalled();
     });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,7 @@ type PersistObject<T> = {
     store: IStore<T>;
     observable: IObservable;
     setItem: (item: Setter<T>) => void;
+    initialData: T;
 };
 
 type PersistProps<T> = {

--- a/src/utils/persist.ts
+++ b/src/utils/persist.ts
@@ -52,5 +52,6 @@ export function persist<T>(props: PersistProps<T>): PersistObject<T> {
         store,
         observable,
         setItem,
+        initialData: props.data
     };
 }

--- a/src/utils/store.ts
+++ b/src/utils/store.ts
@@ -1,5 +1,5 @@
 import { IObservable, IStore } from "interfaces";
-import { useEffect, useState, useSyncExternalStore } from "react";
+import { useSyncExternalStore } from "react";
 import { Observer, PersistObject, Setter } from "../types";
 import { Observable } from "./observable";
 import { syncStoreData } from "./sync";


### PR DESCRIPTION
This PR adds initial data persistence and enhances the store with `serverSnapshot` integration. It ensures the server state is captured and stored reliably for a more consistent user experience.

Additionally, the version has been bumped to **1.0.1**, and tests have been updated to support the `serverSnapshot` integration.

**Key changes:**
- Added data persistence and integrated `serverSnapshot` for improved store reliability.
- Version bumped to **1.0.1**.
- Updated tests for `serverSnapshot` integration.